### PR TITLE
change permission of new created pem file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+.idea
 #Ignore thumbnails created by Windows
 Thumbs.db
 #Ignore files built by Visual Studio

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/sm2/pkcs8.go
+++ b/sm2/pkcs8.go
@@ -425,7 +425,7 @@ func WritePrivateKeytoPem(FileName string, key *PrivateKey, pwd []byte) (bool, e
 			Bytes: der,
 		}
 	}
-	file, err := os.Create(FileName)
+	file, err := os.OpenFile(FileName, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return false, err
 	}
@@ -475,7 +475,7 @@ func WritePublicKeytoPem(FileName string, key *PublicKey, _ []byte) (bool, error
 		Type:  "PUBLIC KEY",
 		Bytes: der,
 	}
-	file, err := os.Create(FileName)
+	file, err := os.OpenFile(FileName, os.O_WRONLY|os.O_CREATE, 0600)
 	defer file.Close()
 	if err != nil {
 		return false, err

--- a/sm2/x509.go
+++ b/sm2/x509.go
@@ -2394,7 +2394,7 @@ func ParseCertificateRequest(asn1Data []byte) (*CertificateRequest, error) {
 
 func parseCertificateRequest(in *certificateRequest) (*CertificateRequest, error) {
 	out := &CertificateRequest{
-		Raw: in.Raw,
+		Raw:                      in.Raw,
 		RawTBSCertificateRequest: in.TBSCSR.Raw,
 		RawSubjectPublicKeyInfo:  in.TBSCSR.PublicKey.Raw,
 		RawSubject:               in.TBSCSR.Subject.FullBytes,
@@ -2482,7 +2482,7 @@ func CreateCertificateRequestToPem(FileName string, template *CertificateRequest
 		Type:  "CERTIFICATE REQUEST",
 		Bytes: der,
 	}
-	file, err := os.Create(FileName)
+	file, err := os.OpenFile(FileName, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return false, err
 	}
@@ -2531,7 +2531,7 @@ func CreateCertificateToPem(FileName string, template, parent *Certificate, pubK
 		Type:  "CERTIFICATE",
 		Bytes: der,
 	}
-	file, err := os.Create(FileName)
+	file, err := os.OpenFile(FileName, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return false, err
 	}

--- a/sm4/sm4.go
+++ b/sm4/sm4.go
@@ -306,7 +306,7 @@ func WriteKeyToPem(FileName string, key SM4Key, pwd []byte) (bool, error) {
 			Bytes: key,
 		}
 	}
-	file, err := os.Create(FileName)
+	file, err := os.OpenFile(FileName, os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fix a security problem of file permission.

Old version creates a new pem file by using `os.Create()` who set the `0666` as the file permission. Those created pem files may be accessed by other users who don't own those files. Thus, I use `os.OpenFile()` to set permission of new file `0600` instead.